### PR TITLE
--no-ri --no-rdoc is deprecated, use --no-document

### DIFF
--- a/ruby/gemrc.symlink
+++ b/ruby/gemrc.symlink
@@ -1,7 +1,7 @@
 ---
 :update_sources: true
 :sources:
-- http://rubygems.org
+- https://rubygems.org
 :benchmark: false
 :backtrace: false
 :verbose: true


### PR DESCRIPTION
Reference: http://guides.rubygems.org/command-reference/
